### PR TITLE
Add Google calendar client routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,19 +113,24 @@ Use the “Simulation” tab in the frontend to test your AI voice assistant:
 
 Endpoints for connecting a business to Google Calendar and scheduling appointments.
 
-### `GET /client/:id/linkGoogle`
+### `GET /client/linkGoogle`
 
+- Query parameter `id` specifies the business.
 - When called without a `code` query parameter the route redirects to Google so the business owner can authorize access.
 - After authorization Google redirects back with `?code=...` and the endpoint stores the refresh token and responds with `{ success: true }`.
 
-### `POST /client/:id/check_availability`
+### `POST /client/check_availability`
+
+- Query parameter `id` specifies the business.
 
 - **Body:**
   - `start` – ISO start datetime
   - `end` – ISO end datetime
 - Returns a list of open 30‑minute slots between `start` and `end` using the linked calendar.
 
-### `POST /client/:id/book_appointment`
+### `POST /client/book_appointment`
+
+- Query parameter `id` specifies the business.
 
 - **Body:**
   - `start` – ISO start datetime

--- a/README.md
+++ b/README.md
@@ -109,6 +109,33 @@ Use the “Simulation” tab in the frontend to test your AI voice assistant:
 
 ---
 
+## Client API
+
+Endpoints for connecting a business to Google Calendar and scheduling appointments.
+
+### `GET /client/:id/linkGoogle`
+
+- When called without a `code` query parameter the route redirects to Google so the business owner can authorize access.
+- After authorization Google redirects back with `?code=...` and the endpoint stores the refresh token and responds with `{ success: true }`.
+
+### `POST /client/:id/check_availability`
+
+- **Body:**
+  - `start` – ISO start datetime
+  - `end` – ISO end datetime
+- Returns a list of open 30‑minute slots between `start` and `end` using the linked calendar.
+
+### `POST /client/:id/book_appointment`
+
+- **Body:**
+  - `start` – ISO start datetime
+  - `end` – ISO end datetime
+  - `customerId` – existing customer ID *(optional)*
+  - `fullName`, `email`, `phoneNumber` – details for a new customer
+  - `description` – notes to include on the event *(optional)*
+- Creates the calendar event and returns `{ success: true, eventId }`.
+
+
 ## 🧱 Future Roadmap
 - 🔄 Google Calendar Sync
 - 🥡 Toast API integration

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,9 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "firebase-admin": "^13.3.0",
-        "twilio": "^5.5.2"
+        "googleapis": "^150.0.1",
+        "twilio": "^5.5.2",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.1",
@@ -3388,6 +3390,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -4250,6 +4261,29 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4447,6 +4481,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -4759,6 +4805,207 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "150.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-150.0.1.tgz",
+      "integrity": "sha512-9Wa9vm3WtDpss0VFBHsbZWcoRccpOSWdpz7YIfb1LBXopZJEg/Zc8ymmaSgvDkP4FhN+pqPS9nZjO7REAJWSUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.0.0-rc.1",
+        "googleapis-common": "^8.0.2-rc.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.2-rc.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.2-rc.0.tgz",
+      "integrity": "sha512-JTcxRvmFa9Ec1uyfMEimEMeeKq1sHNZX3vn2qmoUMtnvixXXvcqTcbDZvEZXkEWpGlPlOf4joyep6/qs0BrLyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.0.0-rc.1",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "7.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.0.0-rc.6.tgz",
+      "integrity": "sha512-osVFpgeBiwTM2AVI9MXvb8iWzM6oSMbTVWc65Gm5BgBlE+nUA6PBHFMaYpqjZx1AhUH7aPOZq78WcRAM6hhAwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gcp-metadata": {
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.0-rc.1.tgz",
+      "integrity": "sha512-E6c+AdIaK1LNA839OyotiTca+B2IG1nDlMjnlcck8JjXn3fVgx57Ib9i6iL1/iqN7bA3EUQdcRRu+HqOCOABIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0-rc.1",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-auth-library": {
+      "version": "10.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.0.0-rc.3.tgz",
+      "integrity": "sha512-WC9wfEKK0bk3seWKsDn2loduLth6JWKTsrbWftzrhPuzpwnVXb5oi2+aa0JDBxLBDdkGesLvTQ67F2nZ7leq1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0-rc.4",
+        "gcp-metadata": "^7.0.0-rc.1",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0-rc.1",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-logging-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gtoken": {
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0-rc.1.tgz",
+      "integrity": "sha512-UjE/egX6ixArdcCKOkheuFQ4XN4/0gX92nd2JPVEYuRU2sWHAWuOVGnowm1fQUdQtaxqn1n8H0hOb2LCaUhJ3A==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0-rc.1",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/googleapis/node_modules/gaxios": {
+      "version": "7.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.0.0-rc.6.tgz",
+      "integrity": "sha512-osVFpgeBiwTM2AVI9MXvb8iWzM6oSMbTVWc65Gm5BgBlE+nUA6PBHFMaYpqjZx1AhUH7aPOZq78WcRAM6hhAwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis/node_modules/gcp-metadata": {
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.0-rc.1.tgz",
+      "integrity": "sha512-E6c+AdIaK1LNA839OyotiTca+B2IG1nDlMjnlcck8JjXn3fVgx57Ib9i6iL1/iqN7bA3EUQdcRRu+HqOCOABIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0-rc.1",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis/node_modules/google-auth-library": {
+      "version": "10.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.0.0-rc.3.tgz",
+      "integrity": "sha512-WC9wfEKK0bk3seWKsDn2loduLth6JWKTsrbWftzrhPuzpwnVXb5oi2+aa0JDBxLBDdkGesLvTQ67F2nZ7leq1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0-rc.4",
+        "gcp-metadata": "^7.0.0-rc.1",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0-rc.1",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis/node_modules/google-logging-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis/node_modules/gtoken": {
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0-rc.1.tgz",
+      "integrity": "sha512-UjE/egX6ixArdcCKOkheuFQ4XN4/0gX92nd2JPVEYuRU2sWHAWuOVGnowm1fQUdQtaxqn1n8H0hOb2LCaUhJ3A==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0-rc.1",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gopd": {
@@ -6537,6 +6784,26 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -8503,6 +8770,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8573,6 +8846,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,9 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "firebase-admin": "^13.3.0",
-    "twilio": "^5.5.2"
+    "googleapis": "^150.0.1",
+    "twilio": "^5.5.2",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",

--- a/backend/src/firebase/__tests__/services.firebaseHelpers.test.ts
+++ b/backend/src/firebase/__tests__/services.firebaseHelpers.test.ts
@@ -35,6 +35,7 @@ const expectedBusiness = {
     testInfo: "testInfo",
   },
   admins: [],
+  googleRefreshToken: undefined,
 };
 
 const mockDb = createMockFirestore({

--- a/backend/src/firebase/dbHelpers.ts
+++ b/backend/src/firebase/dbHelpers.ts
@@ -7,6 +7,7 @@ import { CollectionReference, DocumentData } from "firebase-admin/firestore";
 const COLLECTIONS = {
   store: "call",
   business: "business",
+  customer: "customer",
 } as const;
 
 function getStore(): CollectionReference<DocumentData> {
@@ -15,6 +16,10 @@ function getStore(): CollectionReference<DocumentData> {
 
 function getBusiness(): CollectionReference<DocumentData> {
   return getFirestoreDb().collection(COLLECTIONS.business);
+}
+
+function getCustomer(): CollectionReference<DocumentData> {
+  return getFirestoreDb().collection(COLLECTIONS.customer);
 }
 
 export const saveStoreToFirebase = async (
@@ -46,6 +51,28 @@ export const saveBusinessToFirebase = async (
     .set(business, { merge: true });
   console.log("set business at: ", res.writeTime);
   return business;
+};
+
+export const saveCustomerToFirebase = async (
+  customer: import("../models/customer").Customer,
+): Promise<import("../models/customer").Customer> => {
+  const res = await getCustomer()
+    .doc(customer.id)
+    .set(customer, { merge: true });
+  console.log("set customer at: ", res.writeTime);
+  return customer;
+};
+
+export const fetchCustomerFromFirebase = async (
+  id: string,
+): Promise<import("../models/customer").Customer | void> => {
+  const snapshot = await getCustomer().doc(id).get();
+  if (!snapshot.exists) {
+    console.log("No matching documents");
+    return;
+  }
+  const fetched = snapshot.data() as import("../models/customer").Customer;
+  return fetched;
 };
 
 // TODO: we might wanna remove this

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import { config } from "dotenv";
 config(); // importing early so that other libraries can use env vars
 import twilio from "twilio";
 import twiliorouterRoutes from "./routes/twilioRoutes";
+import clientRoutes from "./routes/clientRoutes";
 
 export const app = express();
 const port = process.env.PORT || 3001;
@@ -16,6 +17,7 @@ app.get("/", (req, resp) => {
 });
 
 app.use("/twilio", twilio.webhook({ validate: false }), twiliorouterRoutes);
+app.use("/client", clientRoutes);
 
 app.get("/health", (req: Request, resp: Response) => {
   resp.send("Server is healthy");

--- a/backend/src/models/business.ts
+++ b/backend/src/models/business.ts
@@ -11,6 +11,7 @@ export interface Business {
   name: string;
   businessInfo: Record<string, string>;
   admins: BusinessUser[];
+  googleRefreshToken?: string;
 }
 
 export function createBusiness(
@@ -26,6 +27,7 @@ export function createBusiness(
     name,
     businessInfo: {},
     admins: [],
+    googleRefreshToken: undefined,
   };
 }
 

--- a/backend/src/models/customer.ts
+++ b/backend/src/models/customer.ts
@@ -1,0 +1,6 @@
+export interface Customer {
+  id: string;
+  fullName: string;
+  email: string;
+  phoneNumber: string;
+}

--- a/backend/src/routes/__tests__/clientRoutes.test.ts
+++ b/backend/src/routes/__tests__/clientRoutes.test.ts
@@ -1,0 +1,18 @@
+import request from "supertest";
+import { app } from "../..";
+import * as firebaseService from "../../firebase/config";
+import { createMockFirestore } from "../../test/mockFirestore";
+import { Firestore } from "firebase-admin/firestore";
+
+describe("Client routes", () => {
+  test("GET /client/:id/linkGoogle redirects", async () => {
+    const mockDb = createMockFirestore({});
+    jest
+      .spyOn(firebaseService, "getFirestoreDb")
+      .mockImplementation(() => mockDb as unknown as Firestore);
+
+    const res = await request(app).get("/client/test_business/linkGoogle");
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain("https://");
+  });
+});

--- a/backend/src/routes/__tests__/clientRoutes.test.ts
+++ b/backend/src/routes/__tests__/clientRoutes.test.ts
@@ -4,6 +4,31 @@ import * as firebaseService from "../../firebase/config";
 import { createMockFirestore } from "../../test/mockFirestore";
 import { Firestore } from "firebase-admin/firestore";
 
+jest.mock("googleapis", () => {
+  const mOAuth = {
+    generateAuthUrl: jest.fn(() => "https://google.com"),
+    getToken: jest.fn(() => ({ tokens: { refresh_token: "rt" } })),
+    setCredentials: jest.fn(),
+  };
+  return {
+    google: {
+      auth: { OAuth2: jest.fn(() => mOAuth) },
+      calendar: jest.fn(() => ({
+        freebusy: {
+          query: jest.fn(() =>
+            Promise.resolve({
+              data: { calendars: { primary: { busy: [{ start: "2024-01-01T00:00:00Z", end: "2024-01-01T00:30:00Z" }] } } },
+            }),
+          ),
+        },
+        events: {
+          insert: jest.fn(() => Promise.resolve({ data: { id: "ev123" } })),
+        },
+      })),
+    },
+  };
+});
+
 describe("Client routes", () => {
   test("GET /client/:id/linkGoogle redirects", async () => {
     const mockDb = createMockFirestore({});
@@ -14,5 +39,46 @@ describe("Client routes", () => {
     const res = await request(app).get("/client/test_business/linkGoogle");
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain("https://");
+  });
+
+  test("POST /client/:id/check_availability returns slots", async () => {
+    const mockDb = createMockFirestore({
+      business: { test_business: { googleRefreshToken: "token" } },
+    });
+    jest
+      .spyOn(firebaseService, "getFirestoreDb")
+      .mockImplementation(() => mockDb as unknown as Firestore);
+
+    const res = await request(app)
+      .post("/client/test_business/check_availability")
+      .send({ start: "2024-01-01T00:00:00Z", end: "2024-01-01T01:00:00Z" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { start: "2024-01-01T00:30:00.000Z", end: "2024-01-01T01:00:00.000Z" },
+    ]);
+  });
+
+  test("POST /client/:id/book_appointment creates event", async () => {
+    const mockDb = createMockFirestore({
+      business: { test_business: { googleRefreshToken: "token", name: "Test", businessInfo: {} } },
+    });
+    jest
+      .spyOn(firebaseService, "getFirestoreDb")
+      .mockImplementation(() => mockDb as unknown as Firestore);
+
+    const res = await request(app)
+      .post("/client/test_business/book_appointment")
+      .send({
+        start: "2024-01-01T00:30:00Z",
+        end: "2024-01-01T01:00:00Z",
+        fullName: "Bob",
+        email: "bob@test.com",
+        phoneNumber: "123",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, eventId: "ev123" });
+    expect(mockDb.__data.customer).toBeDefined();
   });
 });

--- a/backend/src/routes/__tests__/clientRoutes.test.ts
+++ b/backend/src/routes/__tests__/clientRoutes.test.ts
@@ -30,18 +30,20 @@ jest.mock("googleapis", () => {
 });
 
 describe("Client routes", () => {
-  test("GET /client/:id/linkGoogle redirects", async () => {
+  test("GET /client/linkGoogle redirects", async () => {
     const mockDb = createMockFirestore({});
     jest
       .spyOn(firebaseService, "getFirestoreDb")
       .mockImplementation(() => mockDb as unknown as Firestore);
 
-    const res = await request(app).get("/client/test_business/linkGoogle");
+    const res = await request(app).get(
+      "/client/linkGoogle?id=test_business",
+    );
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain("https://");
   });
 
-  test("POST /client/:id/check_availability returns slots", async () => {
+  test("POST /client/check_availability returns slots", async () => {
     const mockDb = createMockFirestore({
       business: { test_business: { googleRefreshToken: "token" } },
     });
@@ -50,7 +52,7 @@ describe("Client routes", () => {
       .mockImplementation(() => mockDb as unknown as Firestore);
 
     const res = await request(app)
-      .post("/client/test_business/check_availability")
+      .post("/client/check_availability?id=test_business")
       .send({ start: "2024-01-01T00:00:00Z", end: "2024-01-01T01:00:00Z" });
 
     expect(res.status).toBe(200);
@@ -59,7 +61,7 @@ describe("Client routes", () => {
     ]);
   });
 
-  test("POST /client/:id/book_appointment creates event", async () => {
+  test("POST /client/book_appointment creates event", async () => {
     const mockDb = createMockFirestore({
       business: { test_business: { googleRefreshToken: "token", name: "Test", businessInfo: {} } },
     });
@@ -68,7 +70,7 @@ describe("Client routes", () => {
       .mockImplementation(() => mockDb as unknown as Firestore);
 
     const res = await request(app)
-      .post("/client/test_business/book_appointment")
+      .post("/client/book_appointment?id=test_business")
       .send({
         start: "2024-01-01T00:30:00Z",
         end: "2024-01-01T01:00:00Z",

--- a/backend/src/routes/clientRoutes.ts
+++ b/backend/src/routes/clientRoutes.ts
@@ -1,0 +1,140 @@
+import { Router, Request, Response } from "express";
+import { google } from "googleapis";
+import { v4 as uuidv4 } from "uuid";
+import {
+  saveBusinessToFirebase,
+  fetchBusinessFromFirebase,
+  saveCustomerToFirebase,
+  fetchCustomerFromFirebase,
+} from "../firebase/dbHelpers";
+import { createBusiness, Business } from "../models/business";
+import { Customer } from "../models/customer";
+
+const router = Router();
+
+function getOAuthClient(redirectUri: string) {
+  return new google.auth.OAuth2(
+    process.env.GOOGLE_CLIENT_ID,
+    process.env.GOOGLE_CLIENT_SECRET,
+    redirectUri,
+  );
+}
+
+router.get("/:id/linkGoogle", async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const code = req.query.code as string | undefined;
+  let business: Business | void = await fetchBusinessFromFirebase(id);
+  if (!business) {
+    business = createBusiness(id, "", "", id);
+    await saveBusinessToFirebase(business);
+  }
+  const redirectUri =
+    process.env.GOOGLE_REDIRECT_URI ||
+    `${req.protocol}://${req.get("host")}/client/${id}/linkGoogle`;
+  const oAuth2Client = getOAuthClient(redirectUri);
+  if (!code) {
+    const url = oAuth2Client.generateAuthUrl({
+      access_type: "offline",
+      scope: ["https://www.googleapis.com/auth/calendar"],
+    });
+    return res.redirect(url);
+  }
+
+  const { tokens } = await oAuth2Client.getToken(code);
+  if (tokens.refresh_token) {
+    (business as Business).googleRefreshToken = tokens.refresh_token;
+    await saveBusinessToFirebase(business as Business);
+  }
+  return res.json({ success: true });
+});
+
+router.post("/:id/check_availability", async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const { start, end } = req.body as { start: string; end: string };
+  const business = await fetchBusinessFromFirebase(id);
+  if (!business || !business.googleRefreshToken) {
+    return res.status(404).json({ error: "business not linked" });
+  }
+  const oAuth2Client = getOAuthClient("postmessage");
+  oAuth2Client.setCredentials({ refresh_token: business.googleRefreshToken });
+  const calendar = google.calendar({ version: "v3", auth: oAuth2Client });
+  const fb = await calendar.freebusy.query({
+    requestBody: {
+      timeMin: new Date(start).toISOString(),
+      timeMax: new Date(end).toISOString(),
+      items: [{ id: "primary" }],
+    },
+  });
+  const busy = fb.data.calendars?.primary?.busy || [];
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  const avail: Array<{ start: string; end: string }> = [];
+  let pointer = new Date(startDate);
+  while (pointer < endDate) {
+    const next = new Date(pointer.getTime() + 30 * 60 * 1000);
+    const overlap = busy.some(
+      (b) => new Date(b.start!) < next && new Date(b.end!) > pointer,
+    );
+    if (!overlap && next <= endDate) {
+      avail.push({ start: pointer.toISOString(), end: next.toISOString() });
+    }
+    pointer = next;
+  }
+  return res.json(avail);
+});
+
+router.post("/:id/book_appointment", async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const {
+    start,
+    end,
+    customerId,
+    fullName,
+    email,
+    phoneNumber,
+    description,
+  } = req.body as {
+    start: string;
+    end: string;
+    customerId?: string;
+    fullName?: string;
+    email?: string;
+    phoneNumber?: string;
+    description?: string;
+  };
+  const business = await fetchBusinessFromFirebase(id);
+  if (!business || !business.googleRefreshToken) {
+    return res.status(404).json({ error: "business not linked" });
+  }
+  let customer: Customer | void;
+  if (customerId) {
+    customer = await fetchCustomerFromFirebase(customerId);
+    if (!customer) return res.status(404).json({ error: "customer not found" });
+  } else {
+    customer = {
+      id: uuidv4(),
+      fullName: fullName || "",
+      email: email || "",
+      phoneNumber: phoneNumber || "",
+    };
+    await saveCustomerToFirebase(customer);
+  }
+  const oAuth2Client = getOAuthClient("postmessage");
+  oAuth2Client.setCredentials({ refresh_token: business.googleRefreshToken });
+  const calendar = google.calendar({ version: "v3", auth: oAuth2Client });
+  const event = await calendar.events.insert({
+    calendarId: "primary",
+    requestBody: {
+      summary: `${(customer as Customer).fullName} Appointment`,
+      description: `${description || ""}\nBusiness: ${business.name}\n$${
+        business.businessInfo.address || ""
+      }\n${business.businessInfo.phone || ""}`,
+      start: { dateTime: new Date(start).toISOString() },
+      end: { dateTime: new Date(end).toISOString() },
+      attendees: [{ email: (customer as Customer).email }],
+    },
+  });
+  return res.json({ success: true, eventId: event.data.id });
+});
+
+export default router;

--- a/backend/src/routes/clientRoutes.ts
+++ b/backend/src/routes/clientRoutes.ts
@@ -20,9 +20,13 @@ function getOAuthClient(redirectUri: string) {
   );
 }
 
-router.get("/:id/linkGoogle", async (req: Request, res: Response) => {
-  const { id } = req.params;
+router.get("/linkGoogle", async (req: Request, res: Response) => {
+  const id = req.query.id as string | undefined;
   const code = req.query.code as string | undefined;
+  if (!id) {
+    res.status(400).json({ error: "missing id" });
+    return;
+  }
   let business: Business | void = await fetchBusinessFromFirebase(id);
   if (!business) {
     business = createBusiness(id, "", "", id);
@@ -30,14 +34,15 @@ router.get("/:id/linkGoogle", async (req: Request, res: Response) => {
   }
   const redirectUri =
     process.env.GOOGLE_REDIRECT_URI ||
-    `${req.protocol}://${req.get("host")}/client/${id}/linkGoogle`;
+    `${req.protocol}://${req.get("host")}/client/linkGoogle?id=${id}`;
   const oAuth2Client = getOAuthClient(redirectUri);
   if (!code) {
     const url = oAuth2Client.generateAuthUrl({
       access_type: "offline",
       scope: ["https://www.googleapis.com/auth/calendar"],
     });
-    return res.redirect(url);
+    res.redirect(url);
+    return;
   }
 
   const { tokens } = await oAuth2Client.getToken(code);
@@ -45,15 +50,21 @@ router.get("/:id/linkGoogle", async (req: Request, res: Response) => {
     (business as Business).googleRefreshToken = tokens.refresh_token;
     await saveBusinessToFirebase(business as Business);
   }
-  return res.json({ success: true });
+  res.json({ success: true });
+  return;
 });
 
-router.post("/:id/check_availability", async (req: Request, res: Response) => {
-  const { id } = req.params;
+router.post("/check_availability", async (req: Request, res: Response) => {
+  const id = req.query.id as string | undefined;
   const { start, end } = req.body as { start: string; end: string };
+  if (!id) {
+    res.status(400).json({ error: "missing id" });
+    return;
+  }
   const business = await fetchBusinessFromFirebase(id);
   if (!business || !business.googleRefreshToken) {
-    return res.status(404).json({ error: "business not linked" });
+    res.status(404).json({ error: "business not linked" });
+    return;
   }
   const oAuth2Client = getOAuthClient("postmessage");
   oAuth2Client.setCredentials({ refresh_token: business.googleRefreshToken });
@@ -80,11 +91,12 @@ router.post("/:id/check_availability", async (req: Request, res: Response) => {
     }
     pointer = next;
   }
-  return res.json(avail);
+  res.json(avail);
+  return;
 });
 
-router.post("/:id/book_appointment", async (req: Request, res: Response) => {
-  const { id } = req.params;
+router.post("/book_appointment", async (req: Request, res: Response) => {
+  const id = req.query.id as string | undefined;
   const {
     start,
     end,
@@ -102,14 +114,22 @@ router.post("/:id/book_appointment", async (req: Request, res: Response) => {
     phoneNumber?: string;
     description?: string;
   };
+  if (!id) {
+    res.status(400).json({ error: "missing id" });
+    return;
+  }
   const business = await fetchBusinessFromFirebase(id);
   if (!business || !business.googleRefreshToken) {
-    return res.status(404).json({ error: "business not linked" });
+    res.status(404).json({ error: "business not linked" });
+    return;
   }
   let customer: Customer | void;
   if (customerId) {
     customer = await fetchCustomerFromFirebase(customerId);
-    if (!customer) return res.status(404).json({ error: "customer not found" });
+    if (!customer) {
+      res.status(404).json({ error: "customer not found" });
+      return;
+    }
   } else {
     customer = {
       id: uuidv4(),
@@ -134,7 +154,8 @@ router.post("/:id/book_appointment", async (req: Request, res: Response) => {
       attendees: [{ email: (customer as Customer).email }],
     },
   });
-  return res.json({ success: true, eventId: event.data.id });
+  res.json({ success: true, eventId: event.data.id });
+  return;
 });
 
 export default router;

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -2,7 +2,8 @@ scaleify/
 ├── backend/ (Node.js + Express)
 │   ├── index.ts
 │   ├── routes/
-│   │   └── twilio.ts
+│   │   ├── twilio.ts
+│   │   └── clientRoutes.ts    # Google Calendar and booking endpoints
 │   ├── services/
 │   │   ├── stt.ts
 │   │   ├── tts.ts

--- a/tasks.md
+++ b/tasks.md
@@ -39,9 +39,9 @@
   - [ ] `calls[]` metadata logger
 - [ ] `tools/bookAppointment.ts`: mock function handler
 - [ ] Express `clientRoutes` for Google Calendar:
-  - `/client/:id/linkGoogle`
-  - `/client/:id/check_availability`
-  - `/client/:id/book_appointment`
+  - `/client/linkGoogle`
+  - `/client/check_availability`
+  - `/client/book_appointment`
 
 ---
 

--- a/tasks.md
+++ b/tasks.md
@@ -38,6 +38,10 @@
   - [ ] `customers[]` by phone
   - [ ] `calls[]` metadata logger
 - [ ] `tools/bookAppointment.ts`: mock function handler
+- [ ] Express `clientRoutes` for Google Calendar:
+  - `/client/:id/linkGoogle`
+  - `/client/:id/check_availability`
+  - `/client/:id/book_appointment`
 
 ---
 


### PR DESCRIPTION
## Summary
- add googleRefreshToken to Business model
- add customer model
- create firestore helpers for customers
- implement clientRoutes with Google Calendar integration
- mount client routes in Express app
- add tests for clientRoutes
- update package.json with googleapis and uuid

## Testing
- `npm test --silent` *(fails: Test Suites never run)*

------
https://chatgpt.com/codex/tasks/task_e_6845df765d3c8320b28407fc8657f6ae